### PR TITLE
fix(cli): handle flags logic

### DIFF
--- a/src/actions/init-action.ts
+++ b/src/actions/init-action.ts
@@ -36,8 +36,8 @@ export const templatesMap: Record<Required<InitOptions>['template'], string> = {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare let _exhaustiveCheck: never;
 
-export async function initAction(_projectName: string, options: InitOptions) {
-  const {package: _package = 'npm', template: _template} = options;
+export async function initAction(_projectName?: string, options: InitOptions = {}) {
+  const {package: _package, template: _template} = options;
 
   /** ======================== Check invalid options ======================== */
   checkInitOptions(_template, _package);
@@ -141,40 +141,44 @@ async function getTableInfo(packageName?: string, projectName?: string, template
     }
   ];
 
-  template = (await selectClack({
-    initialValue: template,
-    message: 'Select a template (Enter to select)',
-    options
-  })) as string;
+  if (!template) {
+    template = (await selectClack({
+      message: 'Select a template (Enter to select)',
+      options
+    })) as string;
+  }
 
-  projectName = (await textClack({
-    initialValue: projectName ?? templatesMap[template],
-    message: 'New project name (Enter to skip with default name)',
-    placeholder: templatesMap[template]
-  })) as string;
+  if (!projectName) {
+    projectName = (await textClack({
+      initialValue: templatesMap[template as keyof typeof templatesMap],
+      message: 'New project name (Enter to skip with default name)',
+      placeholder: templatesMap[template as keyof typeof templatesMap]
+    })) as string;
+  }
 
-  packageName = (await selectClack({
-    initialValue: packageName,
-    message: 'Select a package manager (Enter to select)',
-    options: [
-      {
-        label: chalk.gray('npm'),
-        value: 'npm'
-      },
-      {
-        label: chalk.gray('yarn'),
-        value: 'yarn'
-      },
-      {
-        label: chalk.gray('pnpm'),
-        value: 'pnpm'
-      },
-      {
-        label: chalk.gray('bun'),
-        value: 'bun'
-      }
-    ]
-  })) as Agent;
+  if (!packageName) {
+    packageName = (await selectClack({
+      message: 'Select a package manager (Enter to select)',
+      options: [
+        {
+          label: chalk.gray('npm'),
+          value: 'npm'
+        },
+        {
+          label: chalk.gray('yarn'),
+          value: 'yarn'
+        },
+        {
+          label: chalk.gray('pnpm'),
+          value: 'pnpm'
+        },
+        {
+          label: chalk.gray('bun'),
+          value: 'bun'
+        }
+      ]
+    })) as Agent;
+  }
 
   return {
     packageName: packageName as Agent,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,6 @@ export function registerInitCommand(cmd: Command) {
       '-t --template [string]',
       `Specify a template for the new project, e.g. ${Object.keys(templatesMap).join(', ')}`
     )
-    .option('-p --package [string]', 'The package manager to use for the new project', 'npm')
+    .option('-p --package [string]', 'The package manager to use for the new project')
     .action(initAction);
 }

--- a/src/helpers/init.ts
+++ b/src/helpers/init.ts
@@ -5,7 +5,7 @@ import {templatesMap} from 'src/actions/init-action';
 import {AGENTS, type Agent} from './detect';
 import {printMostMatchText} from './math-diff';
 
-export function checkInitOptions(template: InitOptions['template'], agent: Agent) {
+export function checkInitOptions(template: InitOptions['template'], agent?: Agent) {
   if (template) {
     if (!Object.keys(templatesMap).includes(template)) {
       printMostMatchText(Object.keys(templatesMap), template);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 📝 Description
<!---
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.
-->

This pull request refactors the project initialization flow to improve user experience and flexibility. It makes all initialization options (`projectName`, `package`, and `template`) truly optional, deferring their selection to interactive prompts only if not provided. Additionally, it updates validation logic to support the new optionals and removes default values from the CLI command registration.

**Refactoring for Optional Initialization Options:**

* [`src/actions/init-action.ts`](diffhunk://#diff-c076c1454927dacc08207e6a544cdedd8ed6f55f29c057b395fc5787eb978f05L39-R40): Changed the `initAction` function signature to make both `projectName` and `options` optional, and removed default values for `package` and `template` in the destructuring assignment. Now, if any of these are missing, interactive prompts will request them from the user.
* [`src/commands/init.ts`](diffhunk://#diff-ec8485d3117f43c2d2d8e3ec7b2830f2d6b5df3f20626a62b04f61ccd70ec93fL14-R14): Removed the default value for the `--package` CLI option, so the user is prompted if not specified.
* [`src/actions/init-action.ts`](diffhunk://#diff-c076c1454927dacc08207e6a544cdedd8ed6f55f29c057b395fc5787eb978f05R144-L157): Updated the `getTableInfo` function to only prompt for `template`, `projectName`, or `packageName` if they are not already provided, ensuring a smoother and more flexible initialization process. [[1]](diffhunk://#diff-c076c1454927dacc08207e6a544cdedd8ed6f55f29c057b395fc5787eb978f05R144-L157) [[2]](diffhunk://#diff-c076c1454927dacc08207e6a544cdedd8ed6f55f29c057b395fc5787eb978f05R181)

**Validation Improvements:**

* [`src/helpers/init.ts`](diffhunk://#diff-9b9257363acb6bb723d357a57793f3d8b4f5484eee3a9130c1b30bde3090e93aL8-R8): Updated `checkInitOptions` to accept an optional `agent` parameter, supporting the new logic where the package manager may not be provided up front.

## ✅ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
