### PR TITLE
fix(init): enable download retries and fix exit code on rename failure (fix #189, fix #190)

### DIFF
--- a/src/actions/init-action.ts
+++ b/src/actions/init-action.ts
@@ -106,7 +106,7 @@ function renameTemplate(originName: string, projectName: string) {
   } catch (error) {
     if (error) {
       p.cancel(`rename Error: ${error}`);
-      process.exit(0);
+      process.exit(1);
     }
   }
 }

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -23,22 +23,19 @@ async function fetchTarStream(url: string) {
 
 /**
  * Download the template from the specified URL and extract it to the specified directory.
+ * Retries up to 3 times for transient network errors.
  * @param root
  * @param url
  */
 export async function downloadTemplate(root: string, url: string) {
   await retry(
-    async (bail) => {
-      try {
-        await pipeline(
-          await fetchTarStream(url),
-          tar.x({
-            cwd: root
-          })
-        );
-      } catch (error) {
-        bail(new Error(`Failed to download ${url} Error: ${error}`));
-      }
+    async () => {
+      await pipeline(
+        await fetchTarStream(url),
+        tar.x({
+          cwd: root
+        })
+      );
     },
     {
       retries: 3


### PR DESCRIPTION
Closes #189, #190

## 📝 Description

Two small but impactful bugs in the `heroui init` flow:

### 1. `downloadTemplate` retry logic is dead code (#189)

The `async-retry` wrapper calls `bail()` on every error, which immediately aborts retries. The `retries: 3` config never fires.

**Fix:** Remove the try/catch and let errors propagate naturally so `async-retry` can catch and retry them.

### 2. `renameTemplate` exits with code 0 on failure (#190)

When `renameSync` throws, the function calls `process.exit(0)` — reporting success to the shell. CI/CD pipelines and chained commands can't detect the failure.

**Fix:** Change `process.exit(0)` to `process.exit(1)`.

## ⛳️ Current behavior

- Template download fails once → immediate abort, no retries despite `retries: 3`
- Template rename fails → error message shown but exit code is 0 (success)

## 🚀 New behavior

- Template download retries up to 3 times on transient network errors
- Template rename failure exits with code 1 (failure)

## 💣 Is this a breaking change (Yes/No):

No