### PR TITLE
feat(doctor): add Node.js version and Tailwind CSS checks (fix #193)

### DIFF
--- a/src/actions/doctor-action.ts
+++ b/src/actions/doctor-action.ts
@@ -6,9 +6,18 @@ import {Logger, type PrefixLogType} from '@helpers/logger';
 import {getPackageInfo} from '@helpers/package';
 import {getVersionAndMode, transformPeerVersion} from '@helpers/utils';
 import {resolver} from 'src/constants/path';
-import {DOCS_INSTALLED, HEROUI_PACKAGES, TAILWINDCSS} from 'src/constants/required';
+import {DOCS_INSTALLED, HEROUI_PACKAGES} from 'src/constants/required';
 import {getCacheExecData} from 'src/scripts/cache/cache';
 import {compareVersions} from 'src/scripts/helpers';
+
+/**
+ * Minimum Node.js version, kept in sync with `engines.node` in package.json.
+ * Tailwind CSS is intentionally NOT checked separately here: it is a peer
+ * dependency of @heroui/react and is already covered by the peer-dependency
+ * check below, so a dedicated check would produce two issues for the same
+ * root cause.
+ */
+const MIN_NODE_VERSION = '22.22.0';
 
 export interface ProblemRecord {
   name: string;
@@ -23,116 +32,109 @@ export async function doctorAction(options: DoctorCommandOptions) {
 
   const problemRecord: ProblemRecord[] = [];
 
-  // Check 1: Node.js version meets minimum requirement
+  // Check: Node.js version meets the minimum declared in package.json's
+  // `engines.node` (>=22.22.0). Comparing only the major would falsely
+  // green-light 22.0.0 - 22.21.x.
   const nodeVersion = process.versions.node;
-  const [nodeMajor] = nodeVersion.split('.').map(Number);
 
-  if (nodeMajor != null && nodeMajor < 22) {
+  if (compareVersions(nodeVersion, MIN_NODE_VERSION) < 0) {
     problemRecord.push({
       level: 'error',
       name: 'unsupportedNodeVersion',
       outputFn: () => {
         Logger.log(
-          `Node.js v${nodeVersion} detected, but HeroUI CLI requires Node.js 22 or later.`
+          `Node.js v${nodeVersion} detected, but HeroUI CLI requires Node.js ${MIN_NODE_VERSION} or later.`
         );
         Logger.log(`Current: v${nodeVersion}`);
-        Logger.log(`Required: v22.0.0+`);
+        Logger.log(`Required: v${MIN_NODE_VERSION}+`);
         Logger.newLine();
         Logger.log('Upgrade Node.js: https://nodejs.org/');
       }
     });
   }
 
-  // Check 2: HeroUI packages are installed
+  // Check: HeroUI packages are installed. Recorded (rather than early-
+  // returned) so any earlier problems (e.g. unsupportedNodeVersion) are
+  // still reported in the same output pass.
   const installed = HEROUI_PACKAGES.filter((pkg) => allDependenciesKeys.has(pkg));
 
   if (!installed.length) {
-    Logger.prefix(
-      'error',
-      `❌ No ${chalk.underline(
-        'HeroUI packages'
-      )} found in your project. Please consult the installation guide at: https://heroui.com/docs/react/getting-started/quick-start`
-    );
-
-    return;
-  }
-
-  const missing = HEROUI_PACKAGES.filter((pkg) => !allDependenciesKeys.has(pkg));
-
-  if (missing.length) {
-    problemRecord.push({
-      level: 'warn',
-      name: 'missingHeroUIPackages',
-      outputFn: () => {
-        Logger.log('The following HeroUI packages are not installed:');
-        missing.forEach((pkg) => {
-          Logger.log(`- ${pkg}`);
-        });
-        Logger.newLine();
-        Logger.log('Run `heroui install` to install them.');
-      }
-    });
-  }
-
-  // Check 3: Tailwind CSS is installed
-  if (!allDependenciesKeys.has(TAILWINDCSS)) {
     problemRecord.push({
       level: 'error',
-      name: 'missingTailwindCSS',
+      name: 'noHeroUIPackages',
       outputFn: () => {
-        Logger.log('Tailwind CSS is not installed.');
-        Logger.log('HeroUI v3 requires Tailwind CSS v4.');
+        Logger.log(`No ${chalk.underline('HeroUI packages')} found in your project.`);
         Logger.newLine();
-        Logger.log('Install it with: npm install tailwindcss@latest');
-        Logger.log(`See: ${chalk.underline(DOCS_INSTALLED)}`);
+        Logger.log(
+          `Consult the installation guide at: https://heroui.com/docs/react/getting-started/quick-start`
+        );
       }
     });
-  }
+  } else {
+    const missing = HEROUI_PACKAGES.filter((pkg) => !allDependenciesKeys.has(pkg));
 
-  // Check 4: Peer dependencies are installed and meet minimum versions
-  const missingPeerDeps: string[] = [];
-  const seen = new Set<string>();
+    if (missing.length) {
+      problemRecord.push({
+        level: 'warn',
+        name: 'missingHeroUIPackages',
+        outputFn: () => {
+          Logger.log('The following HeroUI packages are not installed:');
+          missing.forEach((pkg) => {
+            Logger.log(`- ${pkg}`);
+          });
+          Logger.newLine();
+          Logger.log('Run `heroui install` to install them.');
+        }
+      });
+    }
 
-  for (const pkg of installed) {
-    const raw = await getCacheExecData(`npm show ${pkg} peerDependencies --json`);
-    const peerDeps: Record<string, string> = raw ? JSON.parse(raw as SAFE_ANY) : {};
+    // Check: peer dependencies are installed and meet minimum versions.
+    // Tailwind CSS is one of these peer dependencies, so a missing/old
+    // tailwind shows up here automatically — no separate check needed.
+    const missingPeerDeps: string[] = [];
+    const seen = new Set<string>();
 
-    for (const [peerPkg, peerVersion] of Object.entries(peerDeps)) {
-      if (
-        seen.has(peerPkg) ||
-        HEROUI_PACKAGES.includes(peerPkg as (typeof HEROUI_PACKAGES)[number])
-      )
-        continue;
-      seen.add(peerPkg);
+    for (const pkg of installed) {
+      const raw = await getCacheExecData(`npm show ${pkg} peerDependencies --json`);
+      const peerDeps: Record<string, string> = raw ? JSON.parse(raw as SAFE_ANY) : {};
 
-      if (!allDependenciesKeys.has(peerPkg)) {
-        missingPeerDeps.push(`${peerPkg} (${peerVersion})`);
-      } else {
-        const {currentVersion} = getVersionAndMode(allDependencies, peerPkg);
-        const minVersion = transformPeerVersion(peerVersion);
+      for (const [peerPkg, peerVersion] of Object.entries(peerDeps)) {
+        if (
+          seen.has(peerPkg) ||
+          HEROUI_PACKAGES.includes(peerPkg as (typeof HEROUI_PACKAGES)[number])
+        )
+          continue;
+        seen.add(peerPkg);
 
-        if (compareVersions(currentVersion, minVersion) < 0) {
-          missingPeerDeps.push(`${peerPkg} (${peerVersion}, current: ${currentVersion})`);
+        if (!allDependenciesKeys.has(peerPkg)) {
+          missingPeerDeps.push(`${peerPkg} (${peerVersion})`);
+        } else {
+          const {currentVersion} = getVersionAndMode(allDependencies, peerPkg);
+          const minVersion = transformPeerVersion(peerVersion);
+
+          if (compareVersions(currentVersion, minVersion) < 0) {
+            missingPeerDeps.push(`${peerPkg} (${peerVersion}, current: ${currentVersion})`);
+          }
         }
       }
     }
-  }
 
-  if (missingPeerDeps.length) {
-    problemRecord.push({
-      level: 'error',
-      name: 'missingDependencies',
-      outputFn: () => {
-        Logger.log('You have not installed the required dependencies');
-        Logger.newLine();
-        Logger.log('The required dependencies are:');
-        missingPeerDeps.forEach((dependency) => {
-          Logger.log(`- ${dependency}`);
-        });
-        Logger.newLine();
-        Logger.log(`See more info here: ${chalk.underline(DOCS_INSTALLED)}`);
-      }
-    });
+    if (missingPeerDeps.length) {
+      problemRecord.push({
+        level: 'error',
+        name: 'missingDependencies',
+        outputFn: () => {
+          Logger.log('You have not installed the required dependencies');
+          Logger.newLine();
+          Logger.log('The required dependencies are:');
+          missingPeerDeps.forEach((dependency) => {
+            Logger.log(`- ${dependency}`);
+          });
+          Logger.newLine();
+          Logger.log(`See more info here: ${chalk.underline(DOCS_INSTALLED)}`);
+        }
+      });
+    }
   }
 
   if (!problemRecord.length) {

--- a/src/actions/doctor-action.ts
+++ b/src/actions/doctor-action.ts
@@ -6,7 +6,7 @@ import {Logger, type PrefixLogType} from '@helpers/logger';
 import {getPackageInfo} from '@helpers/package';
 import {getVersionAndMode, transformPeerVersion} from '@helpers/utils';
 import {resolver} from 'src/constants/path';
-import {DOCS_INSTALLED, HEROUI_PACKAGES} from 'src/constants/required';
+import {DOCS_INSTALLED, HEROUI_PACKAGES, TAILWINDCSS} from 'src/constants/required';
 import {getCacheExecData} from 'src/scripts/cache/cache';
 import {compareVersions} from 'src/scripts/helpers';
 
@@ -21,6 +21,29 @@ export async function doctorAction(options: DoctorCommandOptions) {
 
   const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
 
+  const problemRecord: ProblemRecord[] = [];
+
+  // Check 1: Node.js version meets minimum requirement
+  const nodeVersion = process.versions.node;
+  const [nodeMajor] = nodeVersion.split('.').map(Number);
+
+  if (nodeMajor != null && nodeMajor < 22) {
+    problemRecord.push({
+      level: 'error',
+      name: 'unsupportedNodeVersion',
+      outputFn: () => {
+        Logger.log(
+          `Node.js v${nodeVersion} detected, but HeroUI CLI requires Node.js 22 or later.`
+        );
+        Logger.log(`Current: v${nodeVersion}`);
+        Logger.log(`Required: v22.0.0+`);
+        Logger.newLine();
+        Logger.log('Upgrade Node.js: https://nodejs.org/');
+      }
+    });
+  }
+
+  // Check 2: HeroUI packages are installed
   const installed = HEROUI_PACKAGES.filter((pkg) => allDependenciesKeys.has(pkg));
 
   if (!installed.length) {
@@ -33,8 +56,6 @@ export async function doctorAction(options: DoctorCommandOptions) {
 
     return;
   }
-
-  const problemRecord: ProblemRecord[] = [];
 
   const missing = HEROUI_PACKAGES.filter((pkg) => !allDependenciesKeys.has(pkg));
 
@@ -53,6 +74,22 @@ export async function doctorAction(options: DoctorCommandOptions) {
     });
   }
 
+  // Check 3: Tailwind CSS is installed
+  if (!allDependenciesKeys.has(TAILWINDCSS)) {
+    problemRecord.push({
+      level: 'error',
+      name: 'missingTailwindCSS',
+      outputFn: () => {
+        Logger.log('Tailwind CSS is not installed.');
+        Logger.log('HeroUI v3 requires Tailwind CSS v4.');
+        Logger.newLine();
+        Logger.log('Install it with: npm install tailwindcss@latest');
+        Logger.log(`See: ${chalk.underline(DOCS_INSTALLED)}`);
+      }
+    });
+  }
+
+  // Check 4: Peer dependencies are installed and meet minimum versions
   const missingPeerDeps: string[] = [];
   const seen = new Set<string>();
 


### PR DESCRIPTION
Closes #193

## 📝 Description

Expands the `doctor` command with two additional checks that catch common setup issues before users hit confusing runtime errors.

### 1. Node.js version check

The README states Node.js 22+ is required, but the `doctor` command didn't verify this. Users on older Node versions (18/20 LTS are still common) get cryptic errors instead of a clear diagnostic.

### 2. Tailwind CSS installation check

The `TAILWINDCSS` constant already existed in `src/constants/required.ts` but wasn't used in the doctor action. While the generic peer dependency check might catch this, a dedicated check provides a more helpful error message explaining that HeroUI v3 specifically requires Tailwind CSS v4.

## Current behavior

```bash
heroui doctor
# Only checks: packages installed + peer deps met
```

## New behavior

```bash
heroui doctor
# Checks: Node version + packages installed + Tailwind CSS + peer deps met
```

Each new check follows the existing `problemRecord` pattern — no new abstractions or dependencies introduced.

## 💣 Is this a breaking change (Yes/No):

No — strictly additive diagnostics. Existing checks are unchanged.

## ✅ Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update