### PR TITLE
feat(cli): add --json output flag to list and env commands

### DIFF
--- a/src/actions/env-action.ts
+++ b/src/actions/env-action.ts
@@ -1,12 +1,13 @@
 import type {EnvOptions} from '@helpers/type';
 
+import {Logger} from '@helpers/logger';
 import {outputComponents, outputInfo} from '@helpers/output-info';
 import {getPackageInfo, transformPackageDetail} from '@helpers/package';
 import {resolver} from 'src/constants/path';
 import {HEROUI_PACKAGES} from 'src/constants/required';
 
 export async function envAction(options: EnvOptions) {
-  const {packagePath = resolver('package.json'), json} = options as EnvOptions & {json?: boolean};
+  const {json, packagePath = resolver('package.json')} = options as EnvOptions & {json?: boolean};
 
   const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
 
@@ -15,23 +16,23 @@ export async function envAction(options: EnvOptions) {
   if (json) {
     const packages = installed.length
       ? (await transformPackageDetail([...installed], allDependencies)).map((c) => ({
+          docs: c.docs,
           package: c.package,
-          version: c.version.replace(/\s*new:\s*/, ' -> ').trim(),
           status: c.status,
-          docs: c.docs
+          version: c.version.replace(/\s*new:\s*/, ' -> ').trim()
         }))
       : [];
 
     const output = {
-      packages,
       environment: {
-        os: process.platform,
         arch: process.arch,
-        nodeVersion: process.version
-      }
+        nodeVersion: process.version,
+        os: process.platform
+      },
+      packages
     };
 
-    console.log(JSON.stringify(output, null, 2));
+    Logger.log(JSON.stringify(output, null, 2));
     process.exit(0);
   }
 

--- a/src/actions/env-action.ts
+++ b/src/actions/env-action.ts
@@ -6,11 +6,34 @@ import {resolver} from 'src/constants/path';
 import {HEROUI_PACKAGES} from 'src/constants/required';
 
 export async function envAction(options: EnvOptions) {
-  const {packagePath = resolver('package.json')} = options;
+  const {packagePath = resolver('package.json'), json} = options as EnvOptions & {json?: boolean};
 
   const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
 
   const installed = HEROUI_PACKAGES.filter((pkg) => allDependenciesKeys.has(pkg));
+
+  if (json) {
+    const packages = installed.length
+      ? (await transformPackageDetail([...installed], allDependencies)).map((c) => ({
+          package: c.package,
+          version: c.version.replace(/\s*new:\s*/, ' -> ').trim(),
+          status: c.status,
+          docs: c.docs
+        }))
+      : [];
+
+    const output = {
+      packages,
+      environment: {
+        os: process.platform,
+        arch: process.arch,
+        nodeVersion: process.version
+      }
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+    process.exit(0);
+  }
 
   if (installed.length) {
     const components = await transformPackageDetail([...installed], allDependencies);

--- a/src/actions/env-action.ts
+++ b/src/actions/env-action.ts
@@ -2,25 +2,20 @@ import type {EnvOptions} from '@helpers/type';
 
 import {Logger} from '@helpers/logger';
 import {outputComponents, outputInfo} from '@helpers/output-info';
-import {getPackageInfo, transformPackageDetail} from '@helpers/package';
+import {getPackageInfo, mapPackageComponentForJson, transformPackageDetail} from '@helpers/package';
 import {resolver} from 'src/constants/path';
 import {HEROUI_PACKAGES} from 'src/constants/required';
 
 export async function envAction(options: EnvOptions) {
-  const {json, packagePath = resolver('package.json')} = options as EnvOptions & {json?: boolean};
+  const {json, packagePath = resolver('package.json')} = options;
 
   const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
 
   const installed = HEROUI_PACKAGES.filter((pkg) => allDependenciesKeys.has(pkg));
 
   if (json) {
-    const packages = installed.length
-      ? (await transformPackageDetail([...installed], allDependencies)).map((c) => ({
-          docs: c.docs,
-          package: c.package,
-          status: c.status,
-          version: c.version.replace(/\s*new:\s*/, ' -> ').trim()
-        }))
+    const components = installed.length
+      ? await transformPackageDetail([...installed], allDependencies)
       : [];
 
     const output = {
@@ -29,7 +24,7 @@ export async function envAction(options: EnvOptions) {
         nodeVersion: process.version,
         os: process.platform
       },
-      packages
+      packages: components.map(mapPackageComponentForJson)
     };
 
     Logger.log(JSON.stringify(output, null, 2));

--- a/src/actions/list-action.ts
+++ b/src/actions/list-action.ts
@@ -8,7 +8,7 @@ import {HEROUI_PACKAGES} from 'src/constants/required';
 import {resolver} from '../../src/constants/path';
 
 export async function listAction(options: CommandOptions) {
-  const {packagePath = resolver('package.json')} = options;
+  const {packagePath = resolver('package.json'), json} = options as CommandOptions & {json?: boolean};
 
   try {
     const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
@@ -16,18 +16,39 @@ export async function listAction(options: CommandOptions) {
     const installed = HEROUI_PACKAGES.filter((pkg) => allDependenciesKeys.has(pkg));
 
     if (!installed.length) {
-      Logger.warn(
-        'No HeroUI packages found. Run `heroui install` to install @heroui/react and @heroui/styles.'
-      );
+      if (json) {
+        console.log(JSON.stringify({packages: []}, null, 2));
+      } else {
+        Logger.warn(
+          'No HeroUI packages found. Run `heroui install` to install @heroui/react and @heroui/styles.'
+        );
+      }
 
       return;
     }
 
     const components = await transformPackageDetail(installed, allDependencies);
 
-    outputComponents({components, message: 'Installed HeroUI packages:\n'});
+    if (json) {
+      const output = {
+        packages: components.map((c) => ({
+          package: c.package,
+          version: c.version.replace(/\s*new:\s*/, ' -> ').trim(),
+          status: c.status,
+          docs: c.docs
+        }))
+      };
+
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      outputComponents({components, message: 'Installed HeroUI packages:\n'});
+    }
   } catch (error) {
-    Logger.prefix('error', `An error occurred while listing packages: ${error}`);
+    if (json) {
+      console.log(JSON.stringify({error: String(error)}, null, 2));
+    } else {
+      Logger.prefix('error', `An error occurred while listing packages: ${error}`);
+    }
   }
 
   process.exit(0);

--- a/src/actions/list-action.ts
+++ b/src/actions/list-action.ts
@@ -8,7 +8,9 @@ import {HEROUI_PACKAGES} from 'src/constants/required';
 import {resolver} from '../../src/constants/path';
 
 export async function listAction(options: CommandOptions) {
-  const {packagePath = resolver('package.json'), json} = options as CommandOptions & {json?: boolean};
+  const {json, packagePath = resolver('package.json')} = options as CommandOptions & {
+    json?: boolean;
+  };
 
   try {
     const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
@@ -17,7 +19,7 @@ export async function listAction(options: CommandOptions) {
 
     if (!installed.length) {
       if (json) {
-        console.log(JSON.stringify({packages: []}, null, 2));
+        Logger.log(JSON.stringify({packages: []}, null, 2));
       } else {
         Logger.warn(
           'No HeroUI packages found. Run `heroui install` to install @heroui/react and @heroui/styles.'
@@ -32,20 +34,20 @@ export async function listAction(options: CommandOptions) {
     if (json) {
       const output = {
         packages: components.map((c) => ({
+          docs: c.docs,
           package: c.package,
-          version: c.version.replace(/\s*new:\s*/, ' -> ').trim(),
           status: c.status,
-          docs: c.docs
+          version: c.version.replace(/\s*new:\s*/, ' -> ').trim()
         }))
       };
 
-      console.log(JSON.stringify(output, null, 2));
+      Logger.log(JSON.stringify(output, null, 2));
     } else {
       outputComponents({components, message: 'Installed HeroUI packages:\n'});
     }
   } catch (error) {
     if (json) {
-      console.log(JSON.stringify({error: String(error)}, null, 2));
+      Logger.log(JSON.stringify({error: String(error)}, null, 2));
     } else {
       Logger.prefix('error', `An error occurred while listing packages: ${error}`);
     }

--- a/src/actions/list-action.ts
+++ b/src/actions/list-action.ts
@@ -2,15 +2,16 @@ import type {CommandOptions} from '../helpers/type';
 
 import {Logger} from '@helpers/logger';
 import {outputComponents} from '@helpers/output-info';
-import {getPackageInfo, transformPackageDetail} from '@helpers/package';
+import {getPackageInfo, mapPackageComponentForJson, transformPackageDetail} from '@helpers/package';
 import {HEROUI_PACKAGES} from 'src/constants/required';
 
 import {resolver} from '../../src/constants/path';
 
+const NO_PACKAGES_MESSAGE =
+  'No HeroUI packages found. Run `heroui install` to install @heroui/react and @heroui/styles.';
+
 export async function listAction(options: CommandOptions) {
-  const {json, packagePath = resolver('package.json')} = options as CommandOptions & {
-    json?: boolean;
-  };
+  const {json, packagePath = resolver('package.json')} = options;
 
   try {
     const {allDependencies, allDependenciesKeys} = getPackageInfo(packagePath);
@@ -18,12 +19,13 @@ export async function listAction(options: CommandOptions) {
     const installed = HEROUI_PACKAGES.filter((pkg) => allDependenciesKeys.has(pkg));
 
     if (!installed.length) {
+      // Always surface the human-readable hint, regardless of mode. In JSON
+      // mode Logger.warn writes to stderr so the JSON on stdout stays clean
+      // and pipe-parseable.
+      Logger.warn(NO_PACKAGES_MESSAGE);
+
       if (json) {
         Logger.log(JSON.stringify({packages: []}, null, 2));
-      } else {
-        Logger.warn(
-          'No HeroUI packages found. Run `heroui install` to install @heroui/react and @heroui/styles.'
-        );
       }
 
       return;
@@ -32,22 +34,13 @@ export async function listAction(options: CommandOptions) {
     const components = await transformPackageDetail(installed, allDependencies);
 
     if (json) {
-      const output = {
-        packages: components.map((c) => ({
-          docs: c.docs,
-          package: c.package,
-          status: c.status,
-          version: c.version.replace(/\s*new:\s*/, ' -> ').trim()
-        }))
-      };
-
-      Logger.log(JSON.stringify(output, null, 2));
+      Logger.log(JSON.stringify({packages: components.map(mapPackageComponentForJson)}, null, 2));
     } else {
       outputComponents({components, message: 'Installed HeroUI packages:\n'});
     }
   } catch (error) {
     if (json) {
-      Logger.log(JSON.stringify({error: String(error)}, null, 2));
+      Logger.error(JSON.stringify({error: String(error)}, null, 2));
     } else {
       Logger.prefix('error', `An error occurred while listing packages: ${error}`);
     }

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -7,5 +7,6 @@ export function registerEnvCommand(cmd: Command) {
     .command('env')
     .description('Displays debugging information for the local environment')
     .option('-p --packagePath [string]', 'Specify the path to the package.json file')
+    .option('--json', 'Output as JSON for programmatic use')
     .action(envAction);
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,5 +7,6 @@ export function registerListCommand(cmd: Command) {
     .command('list')
     .description('Lists installed HeroUI packages (@heroui/react, @heroui/styles)')
     .option('-p --packagePath [string]', 'Specify the path to the package.json file')
+    .option('--json', 'Output as JSON for programmatic use')
     .action(listAction);
 }

--- a/src/helpers/package.ts
+++ b/src/helpers/package.ts
@@ -6,7 +6,7 @@ import {resolve} from 'pathe';
 
 import {HEROUI_PREFIX, HERO_UI} from 'src/constants/required';
 import {getCacheExecData} from 'src/scripts/cache/cache';
-import {getLatestVersion} from 'src/scripts/helpers';
+import {compareVersions, getLatestVersion} from 'src/scripts/helpers';
 
 import {Logger} from './logger';
 import {colorMatchRegex} from './output-info';
@@ -151,4 +151,26 @@ export function getCompleteVersion(upgradeOption: UpgradeOption) {
     colorMatchRegex,
     ''
   )}`;
+}
+
+/**
+ * Re-shape a PackageComponent (whose `version` field is the
+ * `"<current> new: <latest>"` string built by `transformPackageDetail`)
+ * into the discrete `version` / `latestVersion` / `upgradeAvailable`
+ * fields suitable for CI / programmatic consumers of the --json output.
+ */
+export function mapPackageComponentForJson(c: PackageComponent) {
+  const versionMatch = c.version.match(/^(.+?)\s+new:\s+(.+)$/);
+  const version = versionMatch ? versionMatch[1]!.trim() : c.version.trim();
+  const latestVersion = versionMatch ? versionMatch[2]!.trim() : c.version.trim();
+
+  return {
+    docs: c.docs,
+    latestVersion,
+    package: c.package,
+    status: c.status,
+    upgradeAvailable: compareVersions(version, latestVersion) < 0,
+    version,
+    versionMode: c.versionMode
+  };
 }

--- a/src/helpers/type.ts
+++ b/src/helpers/type.ts
@@ -19,10 +19,12 @@ export interface CommandOptions {
   all?: boolean;
   beta?: boolean;
   debug?: boolean;
+  json?: boolean;
 }
 
 export interface EnvOptions extends CommandOptions {
   packagePath?: string;
+  json?: boolean;
 }
 
 export interface DoctorCommandOptions extends CommandOptions {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -12,7 +12,11 @@ import {Logger} from './logger';
 import {colorMatchRegex} from './output-info';
 
 export function getCommandDescAndLog(log: string, desc: string) {
-  Logger.gradient(log);
+  // Suppress the CLI branding banner when running with --json so the JSON
+  // payload on stdout stays clean and pipe-parseable for CI consumers.
+  if (!process.argv.includes('--json')) {
+    Logger.gradient(log);
+  }
 
   return desc;
 }


### PR DESCRIPTION
Closes #192

## 📝 Description

Adds a `--json` flag to the `list` and `env` commands that outputs structured JSON instead of the human-readable box-drawing tables.

### `heroui list --json`

```json
{
  "packages": [
    {
      "package": "@heroui/react",
      "version": "3.0.0 -> 3.0.4",
      "status": "stable",
      "docs": "https://heroui.com"
    },
    {
      "package": "@heroui/styles",
      "version": "3.0.0 -> 3.0.4",
      "status": "stable",
      "docs": "https://heroui.com"
    }
  ]
}
```

### `heroui env --json`

```json
{
  "packages": [...],
  "environment": {
    "os": "darwin",
    "arch": "arm64",
    "nodeVersion": "v22.0.0"
  }
}
```

## Why

- CI/CD pipelines need to parse CLI output programmatically
- Scripts wrapping the CLI can't reliably parse colored table output with ANSI codes
- Other tools (MCP servers, IDE extensions) could consume structured output
- Standard pattern in modern CLIs (npm, yarn, pnpm all support `--json`)

## Implementation

The data was already structured internally as `PackageComponent[]` objects. This PR adds an alternative output path:

1. Added `--json` option to `list` and `env` command registration
2. In each action, checks for the flag and `JSON.stringify`s the data instead of calling `outputComponents()`
3. When `--json` is set, outputs clean JSON to stdout (no banners, no colors)
4. Errors are also output as JSON when the flag is set

## 💣 Is this a breaking change (Yes/No):

No — the flag is opt-in. Default behavior is unchanged.

## ✅ Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update